### PR TITLE
Added ASN.1 VisibleString type

### DIFF
--- a/src/ASN1/ASN1Identifier.php
+++ b/src/ASN1/ASN1Identifier.php
@@ -15,6 +15,7 @@ use Readdle\AppStoreReceiptVerification\ASN1\Universal\Sequence;
 use Readdle\AppStoreReceiptVerification\ASN1\Universal\Set;
 use Readdle\AppStoreReceiptVerification\ASN1\Universal\UTCTime;
 use Readdle\AppStoreReceiptVerification\ASN1\Universal\UTF8String;
+use Readdle\AppStoreReceiptVerification\ASN1\Universal\VisibleString;
 use Readdle\AppStoreReceiptVerification\BufferReader;
 use UnexpectedValueException;
 
@@ -37,6 +38,7 @@ final class ASN1Identifier
     const TYPE__PRINTABLE_STRING = 0x13;
     const TYPE__IA5_STRING = 0x16;
     const TYPE__UTC_TIME = 0x17;
+    const TYPE__VISIBLE_STRING = 0x1A;
 
     const IS_CONTEXT_SPECIFIC = 0b10;
     const IS_CONSTRUCTED = 0b00100000;
@@ -55,6 +57,7 @@ final class ASN1Identifier
         self::TYPE__PRINTABLE_STRING => PrintableString::class,
         self::TYPE__IA5_STRING => IA5String::class,
         self::TYPE__UTC_TIME => UTCTime::class,
+        self::TYPE__VISIBLE_STRING => VisibleString::class,
     ];
 
     const TYPE_TO_STRING = [
@@ -70,6 +73,7 @@ final class ASN1Identifier
         self::TYPE__PRINTABLE_STRING => 'Printable String',
         self::TYPE__IA5_STRING => 'IA5 String',
         self::TYPE__UTC_TIME => 'UTC Time',
+        self::TYPE__VISIBLE_STRING => 'Visible String',
     ];
 
     private int $octet;

--- a/src/ASN1/Universal/VisibleString.php
+++ b/src/ASN1/Universal/VisibleString.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Readdle\AppStoreReceiptVerification\ASN1\Universal;
+
+use Readdle\AppStoreReceiptVerification\ASN1\AbstractASN1Object;
+
+final class VisibleString extends AbstractASN1Object
+{
+    protected string $value = '';
+
+    protected function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Unit/ASN1/ASN1IdentifierTest.php
+++ b/tests/Unit/ASN1/ASN1IdentifierTest.php
@@ -70,7 +70,7 @@ final class ASN1IdentifierTest extends UnitTestCase
             ));
             $this->assertEquals($type, $contextSpecificConstructed->getType());
             $this->assertEquals(
-                'Constructed Context-Specific 0x' . ucfirst(dechex($type)),
+                'Constructed Context-Specific 0x' . strtoupper(dechex($type)),
                 $contextSpecificConstructed->getTypeString()
             );
         }

--- a/tests/Unit/ASN1/Universal/VisibleStringTest.php
+++ b/tests/Unit/ASN1/Universal/VisibleStringTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Readdle\AppStoreReceiptVerification\Tests\Unit\ASN1\Universal;
+
+use Readdle\AppStoreReceiptVerification\ASN1\ASN1Identifier;
+use Readdle\AppStoreReceiptVerification\Tests\Unit\Traits\AsBinaryTestTrait;
+use Readdle\AppStoreReceiptVerification\Tests\Unit\Traits\StringTestTrait;
+use Readdle\AppStoreReceiptVerification\Tests\Unit\UnitTestCase;
+
+final class VisibleStringTest extends UnitTestCase
+{
+    use AsBinaryTestTrait;
+    use StringTestTrait;
+
+    public function testIdentifier(): void
+    {
+        $this->assertEquals(
+            ASN1Identifier::TYPE__VISIBLE_STRING,
+            $this->createASN1Object(ASN1Identifier::TYPE__VISIBLE_STRING, 1)->getIdentifier()->getType()
+        );
+    }
+
+    public function testStringLength(): void
+    {
+        $this->performStringLengthTests(ASN1Identifier::TYPE__VISIBLE_STRING);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $this->assertJsonSerializeResult(ASN1Identifier::TYPE__VISIBLE_STRING, '', '');
+        $this->assertJsonSerializeResult(ASN1Identifier::TYPE__VISIBLE_STRING, 'test', 'test');
+    }
+
+    public function testAsBinary(): void
+    {
+        $this->performAsBinaryTest(ASN1Identifier::TYPE__VISIBLE_STRING, 'test');
+    }
+}


### PR DESCRIPTION
Hey! First of all thank you for great library, it helps us a lot with receipts verification!

**Issue:**
Some of Apple's receipts contain VisibleString field type (https://www.oss.com/asn1/resources/asn1-made-simple/asn1-quick-reference/visiblestring.html) that was not implemented in the library yet.