### PR TITLE
SI-1983 - App Store Receipt Verification library: pending_renewal_info contains ONLY the first subscription state

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php"
   ],
   "homepage": "https://github.com/readdle/app-store-receipt-verification",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "autoload": {
     "psr-4": {
       "Readdle\\AppStoreReceiptVerification\\": "src/"

--- a/src/ReceiptExtender/AppStoreServerAPIReceiptExtender.php
+++ b/src/ReceiptExtender/AppStoreServerAPIReceiptExtender.php
@@ -51,15 +51,16 @@ final class AppStoreServerAPIReceiptExtender implements ReceiptExtenderInterface
         $subscriptionGroupIdentifierItems = $this->api->getAllSubscriptionStatuses($originalTransactionId)->getData();
 
         foreach ($subscriptionGroupIdentifierItems as $subscriptionGroupIdentifierItem) {
-            $addedOriginalTransactionIDs = [];
+            $addedOriginalTransactionIds = [];
+
             foreach ($subscriptionGroupIdentifierItem->getLastTransactions() as $transaction) {
-                $otrID = $transaction->getOriginalTransactionId();
-                if (in_array($otrID, $addedOriginalTransactionIDs)) {
+                if (in_array($transaction->getOriginalTransactionId(), $addedOriginalTransactionIds)) {
                     continue;
                 }
 
                 $renewalInfo = $transaction->getRenewalInfo()->jsonSerialize();
                 $receipt['pending_renewal_info'][] = self::renewalInfoToPendingRenewalInfo($renewalInfo);
+                $addedOriginalTransactionIds[] = $transaction->getOriginalTransactionId();
             }
         }
 

--- a/src/ReceiptExtender/AppStoreServerAPIReceiptExtender.php
+++ b/src/ReceiptExtender/AppStoreServerAPIReceiptExtender.php
@@ -51,9 +51,16 @@ final class AppStoreServerAPIReceiptExtender implements ReceiptExtenderInterface
         $subscriptionGroupIdentifierItems = $this->api->getAllSubscriptionStatuses($originalTransactionId)->getData();
 
         foreach ($subscriptionGroupIdentifierItems as $subscriptionGroupIdentifierItem) {
-            $receipt['pending_renewal_info'][] = self::renewalInfoToPendingRenewalInfo(
-                $subscriptionGroupIdentifierItem->getLastTransactions()[0]->getRenewalInfo()->jsonSerialize()
-            );
+            $addedOriginalTransactionIDs = [];
+            foreach ($subscriptionGroupIdentifierItem->getLastTransactions() as $transaction) {
+                $otrID = $transaction->getOriginalTransactionId();
+                if (in_array($otrID, $addedOriginalTransactionIDs)) {
+                    continue;
+                }
+
+                $renewalInfo = $transaction->getRenewalInfo()->jsonSerialize();
+                $receipt['pending_renewal_info'][] = self::renewalInfoToPendingRenewalInfo($renewalInfo);
+            }
         }
 
         return json_encode($receipt);


### PR DESCRIPTION
Adding renewal info for all transactions in AppStoreServerAPIReceiptExtender::extend()